### PR TITLE
Fix parasol instructions as we moved to stable-2.19

### DIFF
--- a/content/modules/ROOT/pages/30_gitops_env_setup_dev_prod.adoc
+++ b/content/modules/ROOT/pages/30_gitops_env_setup_dev_prod.adoc
@@ -54,7 +54,7 @@ In our case, we want to set up a _parasol-insurance-dev_ overlay.
 [.bordershadow]
 image::01_change_repo_url.png[Change repoUrl]
 
-. Next lets create a new overlay named `parasol-insurance-dev`. Copy `components/argocd/apps/overlays/rhoai-eus-2.16` and paste it as `components/argocd/apps/overlays/parasol-insurance-dev`.
+. Next lets create a new overlay named `parasol-insurance-dev`. Copy `components/argocd/apps/overlays/rhoai-stable-2.19` and paste it as `components/argocd/apps/overlays/parasol-insurance-dev`.
 
 . Change the `line 7` of the `patch-cluster-config-app-of-apps.yaml` file to `path: clusters/overlays/parasol-insurance-dev`.
 


### PR DESCRIPTION
Considering we have everything for 2.19 ([PR](https://github.com/redhat-ai-services/ai-accelerator/pull/121)) and we updated instructions to apply `stable-2.19-aws-gpu` (PR #55), 
this PR fixes parasol instruction to copy from `rhoai-stable-2.19` overlay instead of older versions